### PR TITLE
Parses mixed values; quoted and unquoted

### DIFF
--- a/src/WacAllowParser.js
+++ b/src/WacAllowParser.js
@@ -21,7 +21,7 @@ export default class WacAllowParser {
 
     // Find all user entries in the string
     let entry;
-    const entryMatcher = /(\w+)\s*=\s*"?\s*((?:\s*[^"\s]+)*)\s*"?/g;
+    const entryMatcher = /(\w+)\s*=\s*"?\s*((?:\s*[^",\s]+)*)\s*"?/g;
     while (entry = entryMatcher.exec(value)) {
       // Create a permissions set for the user
       const [, user, allowed] = entry;


### PR DESCRIPTION
This PR should make it possible to parse strings that are double quoted as well as without:

`foo=bar ,user=" READ wriTe Append control ", public=" read append" ,other="read " , baz= write, group=" ",,`

Processing code can eventually generate something along the lines of:

```
baz: Array [ "write" ]
​​​foo: Array [ "bar" ]
​​​group: Array [ "" ]
​​​other: Array [ "read" ]
​​​​public: Array [ "read", "append" ]
​​​​user: Array [ "read", "write", "append", "control" ]
```

I don't use this library, so haven't actually tested here.. sorry :) but used in dokieli: https://github.com/linkeddata/dokieli/blob/f6e2e14645daf06467a946b0d79e423a896ea6d4/src/doc.js#L858

You should probably review =)